### PR TITLE
fix: pin typescript version

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Your project will look something like this:
 
 1. Runs `tsc --init` with these options:
    ```sh
-   npx -p typescript@4 -- \
+   npx -p typescript@4.x -- \
        tsc --init \
        --allowJs --alwaysStrict --checkJs \
        --moduleResolution node \
@@ -66,8 +66,8 @@ Your project will look something like this:
 You may wish to add common script commands for `fmt` and `lint`:
 
 ```sh
-npm pkg set scripts.lint="npx -p typescript@4 -- tsc -p ./jsconfig.json"
-npm pkg set scripts.fmt="npx -p prettier@2 -- prettier -w '**/*.{js,md}'"
+npm pkg set scripts.lint="npx -p typescript@4.x -- tsc -p ./jsconfig.json"
+npm pkg set scripts.fmt="npx -p prettier@2.x -- prettier -w '**/*.{js,md}'"
 ```
 
 ## Bonus: Vim Config

--- a/bin/jswt-init.js
+++ b/bin/jswt-init.js
@@ -376,7 +376,7 @@ async function createTsConfig() {
     let version = await getLatest20xx();
     let args = [
       "-p",
-      "typescript",
+      "typescript@4.x",
       "--",
       "tsc",
       "--init",
@@ -416,7 +416,15 @@ async function createTsConfig() {
 async function getLatest20xx() {
   // error TS6046: Argument for '--target' option must be:
   // 'es3', ... 'es2022', 'esnext'.
-  let args = ["-p", "typescript", "--", "tsc", "--init", "--target", "20xx"];
+  let args = [
+    "-p",
+    "typescript@4.x",
+    "--",
+    "tsc",
+    "--init",
+    "--target",
+    "20xx",
+  ];
   return await exec("npx", args).catch(function (err) {
     let version;
     let re = /\bes\d{4}\b/g;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jswt",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "jswt",
-      "version": "1.4.4",
+      "version": "1.4.5",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "init": "bin/jswt-init.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jswt",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "Turn on transpile-free type hinting for your vanilla JS projects #JSWithTypes",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
Both #18 and #16 seem to be a symptom of having two versions of typescript during the generation process.