### PR TITLE
fix: add missing .github workflow

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jswt",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jswt",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "license": "SEE LICENSE IN LICENSE",
       "bin": {
         "init": "bin/jswt-init.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jswt",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Turn on transpile-free type hinting for your vanilla JS projects #JSWithTypes",
   "main": "index.js",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "type": "module",
   "files": [
+    ".github/*",
     "index.js",
     "bin/*.js",
     "lib/*.js",


### PR DESCRIPTION
Somehow this missing file didn't come up in previous testing.

Already backported to v1.7.1.